### PR TITLE
Fixed website links

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def profile():
 		org = organizations(user)
 
 
-		# If everything goes finez
+		# If everything goes fine
 		return render_template("profile.html", basic=basic, watch=watch, org=org)
 
 	# If request method is get then redirect to 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def profile():
 		org = organizations(user)
 
 
-		# If everything goes fine
+		# If everything goes finez
 		return render_template("profile.html", basic=basic, watch=watch, org=org)
 
 	# If request method is get then redirect to 

--- a/helpers.py
+++ b/helpers.py
@@ -6,101 +6,105 @@ import json
 import os
 
 try:
-	# Getting client id and secret for extending rate limit
-	secret = '?client_id=' + os.environ.get('CLID') + '&client_secret=' + os.environ.get('CLSEC')
+    # Getting client id and secret for extending rate limit
+    secret = '?client_id=' + os.environ.get('CLID') + '&client_secret=' + os.environ.get('CLSEC')
 except:
-	secret = ''
+    secret = ''
 
-# Basic retrival of data from 
+
+# Basic retrival of data from
 # https://api.github.com/users/user_name
 def basic_retrive(user_name):
+    # concatenate user name to create link
+    link = "https://api.github.com/users/" + user_name + secret
+    # empty list for collecting things I need
+    box = []
 
-	# concatenate user name to create link
-	link = "https://api.github.com/users/" + user_name + secret
-	# empty list for collecting things I need
-	box = []
+    # Try to open link and if failed return None
+    try:
+        response = urllib2.urlopen(link)
+        data = json.load(response)
+        if not data:
+            return None
+    except:
+        return None
 
-	# Try to open link and if failed return None
-	try:
-		response = urllib2.urlopen(link)
-		data = json.load(response)
-		if not data:
-			return None
-	except:
-		return None
+    # Check if the link opened is user type
+    if not data['type'] == "User":
+        return None
 
-	# Check if the link opened is user type
-	if not data['type'] == "User":
-		return None
+    box = dict()
+    # Collect everything in box and return box
+    try:
+        box['login'] = data['login']
+        box['avatar_url'] = data['avatar_url']
+        box['html_url'] = data['html_url']
+        box['name'] = data['name']
+        box['company'] = data['company']
 
+        if (("http" not in data['blog']) and (data['blog'] !="")):
+            data['blog'] = str("http://" + data['blog'])
 
-	box = dict()
-	# Collect everything in box and return box 
-	try:
-		box['login'] = data['login']
-		box['avatar_url'] = data['avatar_url']
-		box['html_url'] = data['html_url']
-		box['name'] = data['name']
-		box['company'] = data['company']
-		box['blog'] = data['blog']
-		box['location'] = data['location']
-		box['bio'] = data['bio']
-		box['public_repos'] = data['public_repos']
-		box['public_gists'] = data['public_gists']
-		box['followers'] = data['followers']
-		box['following'] = data['following']
-		return box
-	except:
-		return None
+        box['blog'] = data['blog']
+        box['location'] = data['location']
+        box['bio'] = data['bio']
+        box['public_repos'] = data['public_repos']
+        box['public_gists'] = data['public_gists']
+        box['followers'] = data['followers']
+        box['following'] = data['following']
+        return box
+    except:
+        return None
+
 
 def watch_list(user_name):
-	# concatenate user name to create link
-	link = "https://api.github.com/users/" + user_name + "/subscriptions" + secret
-	
-	# empty list for collecting things I need
-	box = []
+    # concatenate user name to create link
+    link = "https://api.github.com/users/" + user_name + "/subscriptions" + secret
 
-	# Try to open link and if failed return None
-	try:
-		response = urllib2.urlopen(link)
-		data = json.load(response)
-		if not data:
-			return None
-	except:
-		return None
+    # empty list for collecting things I need
+    box = []
 
-	# pack the box with info we need
-	for i in range(len(data)):
-		box_feed = {}
-		box_feed["name"] = data[i]["name"]
-		box_feed["html_url"] = data[i]["html_url"]
-		box.append(box_feed)
+    # Try to open link and if failed return None
+    try:
+        response = urllib2.urlopen(link)
+        data = json.load(response)
+        if not data:
+            return None
+    except:
+        return None
 
-	return box
+    # pack the box with info we need
+    for i in range(len(data)):
+        box_feed = {}
+        box_feed["name"] = data[i]["name"]
+        box_feed["html_url"] = data[i]["html_url"]
+        box.append(box_feed)
+
+    return box
+
 
 def organizations(user_name):
-	# concatenate user name to create link
-	link = "https://api.github.com/users/" + user_name + "/orgs" + secret
-	
-	# empty list for collecting things I need
-	box = []
+    # concatenate user name to create link
+    link = "https://api.github.com/users/" + user_name + "/orgs" + secret
 
-	# Try to open link and if failed return None
-	try:
-		response = urllib2.urlopen(link)
-		data = json.load(response)
-		if not data:
-			return None
-	except:
-		return None
+    # empty list for collecting things I need
+    box = []
 
-	# pack the box with info we need
-	for i in range(len(data)):
-		box_feed = {}
-		box_feed["name"] = data[i]["login"]
-		box_feed["url"] = "https://github.com/" + data[i]["login"]
-		box_feed["icon"] = data[i]["avatar_url"]
-		box.append(box_feed)
+    # Try to open link and if failed return None
+    try:
+        response = urllib2.urlopen(link)
+        data = json.load(response)
+        if not data:
+            return None
+    except:
+        return None
 
-	return box
+    # pack the box with info we need
+    for i in range(len(data)):
+        box_feed = {}
+        box_feed["name"] = data[i]["login"]
+        box_feed["url"] = "https://github.com/" + data[i]["login"]
+        box_feed["icon"] = data[i]["avatar_url"]
+        box.append(box_feed)
 
+    return box


### PR DESCRIPTION
If the user's website link on GitHub does not have "http://" preceding the URL, the URL opens like _http://hostname_/__website_link__ whereas the correct way should be __http://website_link__
I've fixed this issue in the code.

Example for this issue - Just enter "sameerkumar18" as GitHub id as the search input and visit my website.

